### PR TITLE
Update R version dependency from 3.5 to 4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Collate:
     'velocity_ou.R'
 VignetteBuilder: knitr, quarto
 Depends: 
-    R (>= 3.5)
+    R (>= 4.2)
 LazyData: true
 Config/Needs/website: 
   rmarkdown,


### PR DESCRIPTION
This is needed since the |> pipe symbol is used in the code which was included in R 4.2
I noticed this while building the package:
```
> devtools::build()
── R CMD build ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/home/bart/roamR/DESCRIPTION’ ...
─  preparing ‘roamR’:
✔  checking DESCRIPTION meta-information ...
─  installing the package to build vignettes (570ms)
✔  creating vignettes (18.3s)
─  checking for LF line-endings in source and make files and shell scripts (1.3s)
─  checking for empty or unneeded directories
     NB: this package now depends on R (>= 4.2.0)
     WARNING: Added dependency on R >= 4.2.0 because package code uses the
     pipe placeholder syntax added in R 4.2.0
     File(s) using such syntax:
       ‘simulate_agent_disnbs.R’
─  building ‘roamR_0.0.0.9000.tar.gz’
```